### PR TITLE
Update github actions artifact to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Add SPA fallback (404.html)
         run: cp index.html 404.html
         working-directory: subscription-manager/build
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: subscription-manager/build
 
@@ -42,4 +42,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Update GitHub Pages actions (`upload-pages-artifact`, `deploy-pages`) to their latest versions.

This update was performed proactively to improve performance, stability, and security, after confirming that the `actions/upload-artifact@v3` and `actions/download-artifact@v3` actions (slated for deprecation) were not in use.