### PR TITLE
결제일 타입 오류 및 빌드 문제 해결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -459,7 +459,7 @@ const SubscriptionApp = () => {
         currency: data.currency,
         renewDate: data.renew_date,
         startDate: data.start_date,
-        paymentDate: data.payment_date?.toString(),
+        paymentDate: data.payment_date?.toString() || '',
         paymentCard: data.payment_card,
         url: data.url,
         color: data.color,


### PR DESCRIPTION
Add `|| ''` fallback to `paymentDate` assignment to resolve TypeScript type error.

The `paymentDate` property was optional (`paymentDate?: string`) in the interface, but when assigned directly, TypeScript couldn't guarantee it wouldn't be `undefined`, leading to a `Type 'string | undefined' is not assignable to type 'string'` error.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-8046862a-479c-4471-b4a8-63fe2fa0e275) · [Cursor](https://cursor.com/background-agent?bcId=bc-8046862a-479c-4471-b4a8-63fe2fa0e275)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)