### PR TITLE
Fix type error in user creation

### DIFF
--- a/src/components/signup/VerificationStep.tsx
+++ b/src/components/signup/VerificationStep.tsx
@@ -45,8 +45,6 @@ export const VerificationStep: React.FC<VerificationStepProps> = ({
             agree_to_marketing: data.agreeToMarketing,
           },
           emailRedirectTo: process.env.REACT_APP_SUPABASE_AUTH_REDIRECT_URL || `${window.location.origin}/auth/callback`,
-          // 추가 설정
-          shouldCreateUser: true,
         },
       });
 


### PR DESCRIPTION
Remove `shouldCreateUser` from Supabase `signUp` options to resolve TypeScript compilation error.

---

[Open in Web](https://www.cursor.com/agents?id=bc-02d46d04-51cf-4a31-872a-0b5685397679) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-02d46d04-51cf-4a31-872a-0b5685397679)