### PR TITLE
Fix Supabase index error in schema update

### DIFF
--- a/improved_subscription_schema_fixed.sql
+++ b/improved_subscription_schema_fixed.sql
@@ -86,10 +86,7 @@ CREATE TABLE public.notifications (
     title TEXT NOT NULL,
     message TEXT NOT NULL,
     is_read BOOLEAN DEFAULT false,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    
-    -- 인덱스를 위한 제약조건
-    INDEX idx_notifications_user_unread (user_id, is_read, created_at)
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
 -- 8. 알람 히스토리 테이블


### PR DESCRIPTION
Remove invalid `INDEX` definition from `CREATE TABLE` to fix Supabase schema error.

The error `type "idx_notifications_user_unread" does not exist` occurred because PostgreSQL interpreted `INDEX` within `CREATE TABLE` as a data type, not an index definition. The index is correctly created later in the script using `CREATE INDEX`.

---

[Open in Web](https://www.cursor.com/agents?id=bc-9e8f3e0f-2e89-4863-b78f-f5974e554699) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9e8f3e0f-2e89-4863-b78f-f5974e554699)