### PR TITLE
Fix icon sizes across browser changes

### DIFF
--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -42,7 +42,7 @@ const Header: React.FC<HeaderProps> = ({
             variant="ghost"
             className="flex items-center gap-2 lg:gap-3 w-12 h-12 md:w-14 md:h-14 lg:w-auto lg:h-16 lg:px-6 bg-white/20 rounded-full hover:bg-white/40 focus:bg-white/40 transition-all duration-200 backdrop-blur-sm border border-white/20 hover:border-white/40 focus:border-white/40 active:scale-95 hover:scale-105 focus:scale-105 pointer-events-auto cursor-pointer shadow-lg hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-white/50"
           >
-            <Home className="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 text-white" />
+            <Home className="w-6 h-6 text-white" />
             <span className="hidden lg:inline text-white font-medium text-lg">홈</span>
           </Button>
         </div>
@@ -60,7 +60,7 @@ const Header: React.FC<HeaderProps> = ({
               variant="ghost"
               className="flex items-center gap-2 lg:gap-3 w-12 h-12 md:w-14 md:h-14 lg:w-auto lg:h-16 lg:px-6 bg-white/20 rounded-full hover:bg-white/40 focus:bg-white/40 transition-all duration-200 backdrop-blur-sm border border-white/20 hover:border-white/40 focus:border-white/40 active:scale-95 hover:scale-105 focus:scale-105 pointer-events-auto cursor-pointer shadow-lg hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-white/50"
             >
-              <Bell className="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 text-white" />
+              <Bell className="w-6 h-6 text-white" />
               <span className="hidden lg:inline text-white font-medium text-lg">알림</span>
             </Button>
             {notificationCount > 0 && (
@@ -84,14 +84,14 @@ const Header: React.FC<HeaderProps> = ({
             className="flex items-center gap-2 lg:gap-3 w-12 h-12 md:w-14 md:h-14 lg:w-auto lg:h-16 lg:px-6 bg-white/20 rounded-full hover:bg-white/40 focus:bg-white/40 transition-all duration-200 backdrop-blur-sm border border-white/20 hover:border-white/40 focus:border-white/40 overflow-hidden active:scale-95 hover:scale-105 focus:scale-105 pointer-events-auto cursor-pointer shadow-lg hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-white/50"
           >
             {profile?.photo ? (
-              <Avatar className="w-12 h-12 md:w-14 md:h-14 lg:w-16 lg:h-16">
+              <Avatar className="w-14 h-14">
                 <AvatarImage src={profile.photo} alt="프로필 사진" />
                 <AvatarFallback className="bg-white/20 text-white text-sm md:text-base lg:text-lg">
                   {getInitials(`${profile.firstName} ${profile.lastName}`)}
                 </AvatarFallback>
               </Avatar>
             ) : (
-              <User className="w-5 h-5 md:w-6 md:h-6 lg:w-7 lg:h-7 text-white" />
+              <User className="w-6 h-6 text-white" />
             )}
             <span className="hidden lg:inline text-white font-medium text-lg">프로필</span>
           </Button>


### PR DESCRIPTION
메인 헤더의 홈, 알림, 아바타 아이콘 크기를 브라우저 변경에 상관없이 고정합니다.

이전에는 아이콘들이 브라우저 크기에 따라 반응형으로 크기가 조절되었으나, 이제는 일관된 사용자 경험을 위해 고정된 크기를 유지합니다.

---

[Open in Web](https://www.cursor.com/agents?id=bc-e22d599f-0aef-479f-9324-dfef9f204c5f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e22d599f-0aef-479f-9324-dfef9f204c5f)