### PR TITLE
Fix typescript error in build

### DIFF
--- a/src/components/EnhancedSubscriptionApp.tsx
+++ b/src/components/EnhancedSubscriptionApp.tsx
@@ -126,7 +126,7 @@ export const EnhancedSubscriptionApp: React.FC = () => {
     return await performanceMonitor.measureOperation('addSubscription', async () => {
       try {
         // Enhanced validation
-        const validation = validateSubscriptionFormEnhanced(formData, subscriptions.map(s => ({ id: s.databaseId, name: s.name })));
+        const validation = validateSubscriptionFormEnhanced(formData, subscriptions.filter(s => s.databaseId).map(s => ({ id: s.databaseId!, name: s.name })));
         
         if (!validation.isValid) {
           const errorMessages = Object.values(validation.errors).join(', ');
@@ -171,7 +171,7 @@ export const EnhancedSubscriptionApp: React.FC = () => {
         // Enhanced validation
         const validation = validateSubscriptionFormEnhanced(
           formData, 
-          subscriptions.map(s => ({ id: s.databaseId, name: s.name })),
+          subscriptions.filter(s => s.databaseId).map(s => ({ id: s.databaseId!, name: s.name })),
           subscription.databaseId
         );
         
@@ -483,7 +483,7 @@ export const EnhancedSubscriptionApp: React.FC = () => {
               setEditingSubscription(null);
               setCurrentScreen('main');
             }}
-            existingSubscriptions={subscriptions.map(s => ({ id: s.databaseId, name: s.name }))}
+            existingSubscriptions={subscriptions.filter(s => s.databaseId).map(s => ({ id: s.databaseId!, name: s.name }))}
             isEditing={currentScreen === 'edit'}
             editingId={editingSubscription ? subscriptions.find(s => s.id === editingSubscription)?.databaseId : undefined}
           />


### PR DESCRIPTION
Fix TypeScript compilation error by ensuring `databaseId` is defined when passed to validation.

The `validateSubscriptionFormEnhanced` function expected `id` to be of type `string`, but `s.databaseId` could be `undefined`, leading to a type incompatibility. This PR filters out subscriptions without a `databaseId` before mapping them for validation.

---

[Open in Web](https://www.cursor.com/agents?id=bc-8ae0bc8d-b161-44b0-9afe-2da3c8992182) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-8ae0bc8d-b161-44b0-9afe-2da3c8992182)