### PR TITLE
Run react build with eslint error

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -4478,6 +4478,15 @@
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
       }
     },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
+      }
+    },
     "node_modules/@tanstack/react-virtual": {
       "version": "3.13.12",
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@radix-ui/react-tooltip": "^1.2.7",
         "@supabase/supabase-js": "^2.52.0",
         "@tailwindcss/forms": "^0.5.10",
+        "@tailwindcss/line-clamp": "^0.4.4",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -4517,6 +4518,15 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@tanstack/react-virtual": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "@supabase/supabase-js": "^2.52.0",
     "@tailwindcss/forms": "^0.5.10",
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1901,8 +1901,7 @@ interface Profile {
   // 메인 구독 관리 화면
   if (currentScreen === 'main') {
     return (
-      <>
-        <div className="min-h-screen bg-gradient-to-b from-blue-900 via-blue-800 to-blue-700" style={{ fontFamily: "'Nanum Gothic', sans-serif" }}>
+      <div className="min-h-screen bg-gradient-to-b from-blue-900 via-blue-800 to-blue-700" style={{ fontFamily: "'Nanum Gothic', sans-serif" }}>
         <link
           href="https://fonts.googleapis.com/css2?family=Nanum+Gothic:wght@400;700;800&display=swap"
           rel="stylesheet"
@@ -2304,7 +2303,7 @@ interface Profile {
         isVisible={showEmergencyTroubleshooter}
         onClose={() => setShowEmergencyTroubleshooter(false)}
       />
-      </>
+      </div>
     );
   }
 

--- a/src/utils/responsive-debug.ts
+++ b/src/utils/responsive-debug.ts
@@ -62,8 +62,8 @@ export const getScreenInfo = (): ScreenInfo => {
       height: window.innerHeight
     },
     device: {
-      width: screen.width,
-      height: screen.height,
+      width: window.screen.width,
+      height: window.screen.height,
       ratio: window.devicePixelRatio
     },
     breakpoint: getCurrentBreakpoint(),
@@ -148,7 +148,7 @@ export const checkImageLoading = (): ImageStatus => {
 export const checkElementOverlap = (): Array<{element1: Element, element2: Element}> => {
   const overlapping: Array<{element1: Element, element2: Element}> = [];
   const elements = Array.from(document.querySelectorAll('*')).filter(el => 
-    el.offsetWidth > 0 && el.offsetHeight > 0
+    (el as HTMLElement).offsetWidth > 0 && (el as HTMLElement).offsetHeight > 0
   );
 
   for (let i = 0; i < elements.length; i++) {


### PR DESCRIPTION
Fix build failure due to JSX syntax error and resolve subsequent ESLint/TypeScript issues.

The initial build failure was caused by a syntax error in `src/App.tsx` where a React Fragment (`<>`) was incorrectly paired with a `</div>` closing tag. This PR corrects the JSX structure by changing the fragment to a `<div>`. Additionally, it addresses a missing `@tailwindcss/line-clamp` dependency, ESLint errors related to `screen` global usage, and TypeScript errors requiring `HTMLElement` casting for `offsetWidth`/`offsetHeight` properties, all of which emerged during the build process after the primary syntax fix.

---

[Open in Web](https://www.cursor.com/agents?id=bc-a8c63e7a-b4bb-4b11-bf88-956972ecb37d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a8c63e7a-b4bb-4b11-bf88-956972ecb37d)