### PR TITLE
Fix react hook rule violations in build

### DIFF
--- a/src/components/AuthTestPage.tsx
+++ b/src/components/AuthTestPage.tsx
@@ -4,7 +4,7 @@ import { LoginForm } from './LoginForm';
 import { UserProfile } from './UserProfile';
 
 export function AuthTestPage() {
-  const { isAuthenticated, isLoading, user, profile, error } = useAuth();
+  const { isAuthenticated, isLoading, user, profile, error, diagnoseIssues } = useAuth();
   const [diagnosticResult, setDiagnosticResult] = useState<{
     issues: string[];
     recommendations: string[];
@@ -12,7 +12,6 @@ export function AuthTestPage() {
 
   const handleDiagnose = async () => {
     try {
-      const { diagnoseIssues } = useAuth();
       const result = await diagnoseIssues();
       setDiagnosticResult(result);
     } catch (error) {

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useAuth } from './AuthProvider';
 
 export function LoginForm() {
-  const { signInWithGoogle, isLoading, error } = useAuth();
+  const { signInWithGoogle, isLoading, error, diagnoseIssues } = useAuth();
   const [diagnosticResult, setDiagnosticResult] = useState<{
     issues: string[];
     recommendations: string[];
@@ -18,7 +18,6 @@ export function LoginForm() {
 
   const handleDiagnose = async () => {
     try {
-      const { diagnoseIssues } = useAuth();
       const result = await diagnoseIssues();
       setDiagnosticResult(result);
     } catch (error) {

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -7,7 +7,7 @@ interface ProtectedRouteProps {
   fallback?: React.ReactNode;
 }
 
-export function ProtectedRoute({ children, fallback }: ProtectedRouteProps) {
+export function ProtectedRoute({ children, fallback }: ProtectedRouteProps): React.ReactElement {
   const { isAuthenticated, isLoading } = useAuth();
 
   if (isLoading) {
@@ -22,8 +22,8 @@ export function ProtectedRoute({ children, fallback }: ProtectedRouteProps) {
   }
 
   if (!isAuthenticated) {
-    return fallback || <LoginForm />;
+    return fallback ? <>{fallback}</> : <LoginForm />;
   }
 
-  return <>{children}</>;
+  return <div>{children}</div>;
 }


### PR DESCRIPTION
Fixes build errors by refactoring React Hook usage and resolving TypeScript issues in `ProtectedRoute`.

The `useAuth` hook was incorrectly called inside `handleDiagnose` functions in `AuthTestPage` and `LoginForm`, violating React Rules of Hooks. Additionally, `ProtectedRoute` had TypeScript compilation errors because its return value (fragments or `fallback` prop) was not always recognized as a valid `ReactElement`. These changes ensure compliance with React Hook rules and proper TypeScript typing for JSX elements.

---

[Open in Web](https://www.cursor.com/agents?id=bc-69176e72-e903-4d09-b677-40d077b04436) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-69176e72-e903-4d09-b677-40d077b04436)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)