### PR TITLE
Build project with eslint fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,10 @@ import DebugPanel from './components/DebugPanel';
 import { Button } from './components/ui/button';
 import TestPage from './pages/TestPage';
 import { createDebugObject } from './utils/responsive-debug';
+import { ErrorDisplay } from './components/ErrorDisplay';
+import { ErrorActionGenerator, useErrorHandler } from './lib/errorHandlingSystem';
+import { subscriptionErrorHandlers } from './lib/supabaseWithErrorHandling';
+import { useNetworkStatus } from './lib/networkRecovery';
 
 
 // --- 타입 정의 ---
@@ -94,6 +98,8 @@ interface Profile {
   // --- 컴포넌트 시작 ---
   const SubscriptionApp = () => {
     const { user, profile: supabaseProfile, loading: authLoading, signOut, supabase, updateProfile: updateSupabaseProfile } = useSupabase();
+    const { handleError } = useErrorHandler();
+    const { isOnline } = useNetworkStatus();
 
     // 반응형 디버깅 도구 초기화
     React.useEffect(() => {
@@ -148,6 +154,22 @@ interface Profile {
     notifications: true,
     iconImage: ''
   });
+
+  // Missing state variables
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [currentError, setCurrentError] = useState<any>(null);
+  
+  // Missing refs
+  const dataLoaded = useRef(false);
+
+  // Missing functions
+  const clearError = () => {
+    setCurrentError(null);
+  };
+
+  const retryLastAction = async (action: () => void | Promise<void>) => {
+    return await action();
+  };
 
   // 1. 컴포넌트 마운트/언마운트 정리
   useEffect(() => {
@@ -3015,15 +3037,16 @@ interface Profile {
 // 메인 앱 컴포넌트를 라우팅으로 감싸기
 const App = () => {
   return (
-
-      <Router>
-        <Routes>
-          <Route path="/auth/callback" element={<AuthCallback />} />
-          <Route path="/test" element={<TestPage />} />
-          <Route path="/safe" element={<SafeSubscriptionApp />} />
-          <Route path="/error-test" element={<ErrorScenarioTester />} />
-          <Route path="/supabase-test" element={<SupabaseConnectionTest />} />
-
+    <Router>
+      <Routes>
+        <Route path="/auth/callback" element={<AuthCallback />} />
+        <Route path="/test" element={<TestPage />} />
+        <Route path="/safe" element={<SafeSubscriptionApp />} />
+        <Route path="/error-test" element={<ErrorScenarioTester />} />
+        <Route path="/supabase-test" element={<SupabaseConnectionTest />} />
+        <Route path="/" element={<SafeSubscriptionApp />} />
+      </Routes>
+    </Router>
   );
 };
 

--- a/src/lib/networkRecovery.ts
+++ b/src/lib/networkRecovery.ts
@@ -1,3 +1,4 @@
+import { useState, useEffect, useCallback } from 'react';
 import { AppError, ErrorMessageGenerator } from './errorHandlingSystem';
 
 export interface RetryConfig {
@@ -262,5 +263,3 @@ export function useNetworkRecovery() {
   };
 }
 
-// React import 추가
-import { useState, useEffect, useCallback } from 'react';


### PR DESCRIPTION
Fix build failures by resolving syntax, import, and variable definition errors in `App.tsx` and `networkRecovery.ts`.

The `npm run build` command was failing due to an initial JSX syntax error in `App.tsx`. This fix addresses that, along with subsequent missing imports, state variables, and function definitions that became apparent after the initial fix, and corrects import order in `networkRecovery.ts`.

---

[Open in Web](https://www.cursor.com/agents?id=bc-96cfaf16-68fb-4e84-b16b-fac833f9c18d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-96cfaf16-68fb-4e84-b16b-fac833f9c18d)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)