### PR TITLE
Fix google login redirect issue

### DIFF
--- a/GOOGLE_OAUTH_CHECKLIST.md
+++ b/GOOGLE_OAUTH_CHECKLIST.md
@@ -1,0 +1,108 @@
+# 🔧 Google OAuth 문제 해결 체크리스트
+
+## 🚨 현재 문제 상황
+- URL: `https://your-project.supabase.co/auth/v1/authorize?provider=google&redirect_to=https%3A%2F%2Ftravel.moonwave.kr%2Ftravels&code_challenge=c1EDGRQEi_0JBdQ_ol30y4L9bQdZHtlO8FcbXO0xjrw&code_challenge_method=s256`
+- 문제: `travel.moonwave.kr/travels`로 리다이렉트되지만 설정된 URL은 `subscription.moonwave.kr/#/auth/callback`
+
+## ✅ 해결 체크리스트
+
+### 1. 환경 변수 설정 확인
+- [ ] `.env` 파일에서 `REACT_APP_SITE_URL=https://subscription.moonwave.kr` 확인
+- [ ] `.env` 파일에서 `REACT_APP_SUPABASE_AUTH_REDIRECT_URL=https://subscription.moonwave.kr/#/auth/callback` 확인
+- [ ] `.env` 파일에서 `REACT_APP_GOOGLE_CLIENT_ID`가 올바른 Google OAuth Client ID인지 확인
+
+### 2. Google Cloud Console 설정
+- [ ] Google Cloud Console 접속
+- [ ] APIs & Services → Credentials → OAuth 2.0 Client IDs 선택
+- [ ] Authorized redirect URIs에 다음 URL들 추가:
+  ```
+  https://subscription.moonwave.kr/#/auth/callback
+  https://subscription.moonwave.kr/auth/callback
+  https://hmgxlxnrarciimggycxj.supabase.co/auth/v1/callback
+  ```
+- [ ] 변경사항 저장
+
+### 3. Supabase Dashboard 설정
+- [ ] Supabase Dashboard 접속
+- [ ] Authentication → URL Configuration
+- [ ] Site URL을 `https://subscription.moonwave.kr`로 설정
+- [ ] Redirect URLs에 다음 추가:
+  ```
+  https://subscription.moonwave.kr/#/auth/callback
+  https://subscription.moonwave.kr/auth/callback
+  ```
+- [ ] 변경사항 저장
+
+### 4. 코드 수정 확인
+- [ ] `src/components/LoginScreen.tsx`에서 리다이렉트 URL 로깅 추가됨
+- [ ] `src/lib/supabase.ts`에서 OAuth 리다이렉트 URL 설정 추가됨
+- [ ] `src/components/GoogleAuthDebug.tsx`에서 상세한 디버깅 정보 추가됨
+
+### 5. 브라우저 테스트
+- [ ] 브라우저 캐시 삭제 (Ctrl + Shift + R)
+- [ ] 개발자 도구 열기 (F12)
+- [ ] Console 탭에서 오류 메시지 확인
+- [ ] Network 탭에서 OAuth 요청/응답 확인
+- [ ] 우측 하단 "Show Debug" 버튼 클릭하여 디버그 정보 확인
+
+### 6. 추가 확인사항
+- [ ] HTTPS 연결 확인 (프로덕션 환경)
+- [ ] 팝업 차단 설정 확인
+- [ ] 브라우저 확장 프로그램으로 인한 차단 확인
+- [ ] VPN 사용 중인 경우 VPN 해제 후 테스트
+
+## 🔍 디버깅 단계
+
+### 1단계: 환경 변수 확인
+```bash
+# 브라우저 콘솔에서 실행
+console.log('Site URL:', process.env.REACT_APP_SITE_URL);
+console.log('Auth Redirect URL:', process.env.REACT_APP_SUPABASE_AUTH_REDIRECT_URL);
+console.log('Google Client ID:', process.env.REACT_APP_GOOGLE_CLIENT_ID);
+```
+
+### 2단계: OAuth URL 생성 테스트
+```bash
+# 브라우저 콘솔에서 실행
+const { data, error } = await supabase.auth.signInWithOAuth({
+  provider: 'google',
+  options: {
+    redirectTo: 'https://subscription.moonwave.kr/#/auth/callback',
+    skipBrowserRedirect: true,
+  }
+});
+console.log('OAuth URL:', data.url);
+console.log('Error:', error);
+```
+
+### 3단계: URL 파라미터 분석
+```bash
+# 생성된 OAuth URL의 파라미터 확인
+const url = new URL(data.url);
+console.log('Provider:', url.searchParams.get('provider'));
+console.log('Redirect To:', url.searchParams.get('redirect_to'));
+```
+
+## 🚨 문제 지속 시 확인사항
+
+1. **Supabase 로그 확인**
+   - Supabase Dashboard → Authentication → Logs
+   - OAuth 관련 오류 메시지 확인
+
+2. **Google Cloud Console 로그 확인**
+   - Google Cloud Console → APIs & Services → OAuth consent screen
+   - 동의 화면 설정 확인
+
+3. **네트워크 연결 확인**
+   - 인터넷 연결 상태 확인
+   - 방화벽 설정 확인
+   - DNS 설정 확인
+
+## 📞 지원 정보
+
+문제가 지속되는 경우 다음 정보를 포함하여 문의:
+- 브라우저 콘솔 로그
+- Supabase Authentication 로그
+- Google Cloud Console 설정 스크린샷
+- 현재 사용 중인 브라우저와 OS 정보
+- 재현 단계 상세 설명

--- a/GOOGLE_OAUTH_FIX.md
+++ b/GOOGLE_OAUTH_FIX.md
@@ -1,0 +1,94 @@
+# 🔧 Google OAuth 문제 해결 가이드
+
+## 🚨 현재 문제 분석
+
+제공된 URL을 분석한 결과:
+```
+https://your-project.supabase.co/auth/v1/authorize?provider=google&redirect_to=https%3A%2F%2Ftravel.moonwave.kr%2Ftravels&code_challenge=c1EDGRQEi_0JBdQ_ol30y4L9bQdZHtlO8FcbXO0xjrw&code_challenge_method=s256
+```
+
+### 문제점들:
+1. **리다이렉트 URL 불일치**: `travel.moonwave.kr/travels`로 리다이렉트되지만, 설정된 URL은 `subscription.moonwave.kr/#/auth/callback`
+2. **도메인 불일치**: `travel.moonwave.kr` vs `subscription.moonwave.kr`
+3. **경로 불일치**: `/travels` vs `/#/auth/callback`
+
+## 🔧 해결 방법
+
+### 1. 환경 변수 확인 및 수정
+
+현재 `.env` 파일 설정:
+```
+REACT_APP_SITE_URL=https://subscription.moonwave.kr
+REACT_APP_SUPABASE_AUTH_REDIRECT_URL=https://subscription.moonwave.kr/#/auth/callback
+```
+
+### 2. Google Cloud Console 설정
+
+1. **Google Cloud Console** 접속
+2. **APIs & Services** → **Credentials**
+3. **OAuth 2.0 Client IDs** 선택
+4. **Authorized redirect URIs**에 다음 URL들 추가:
+   ```
+   https://subscription.moonwave.kr/#/auth/callback
+   https://subscription.moonwave.kr/auth/callback
+   https://hmgxlxnrarciimggycxj.supabase.co/auth/v1/callback
+   ```
+
+### 3. Supabase Dashboard 설정
+
+1. **Supabase Dashboard** 접속
+2. **Authentication** → **URL Configuration**
+3. **Site URL**을 `https://subscription.moonwave.kr`로 설정
+4. **Redirect URLs**에 다음 추가:
+   ```
+   https://subscription.moonwave.kr/#/auth/callback
+   https://subscription.moonwave.kr/auth/callback
+   ```
+
+### 4. 코드 수정 사항
+
+`src/components/LoginScreen.tsx`에서 리다이렉트 URL 로깅 추가:
+```typescript
+// 리다이렉트 URL 설정
+const redirectUrl = `${siteUrl}/#/auth/callback`;
+addDebugInfo(`Redirect URL: ${redirectUrl}`);
+```
+
+### 5. 테스트 방법
+
+1. **브라우저 개발자 도구** 열기 (F12)
+2. **Console** 탭에서 다음 로그 확인:
+   - `Using site URL: https://subscription.moonwave.kr`
+   - `Redirect URL: https://subscription.moonwave.kr/#/auth/callback`
+3. **Network** 탭에서 OAuth 요청 확인
+
+### 6. 추가 디버깅
+
+개발 환경에서 우측 하단의 "Show Debug" 버튼을 클릭하여:
+- 환경 변수 설정 상태
+- Supabase 클라이언트 상태
+- OAuth URL 생성 결과
+- 오류 상세 정보 확인
+
+## 🚨 주의사항
+
+1. **HTTPS 필수**: 프로덕션 환경에서는 반드시 HTTPS 사용
+2. **도메인 일치**: Google Cloud Console과 Supabase Dashboard의 도메인 설정이 일치해야 함
+3. **캐시 문제**: 브라우저 캐시 삭제 후 재시도
+4. **팝업 차단**: 브라우저 팝업 차단 설정 확인
+
+## 🔗 유용한 링크
+
+- [Supabase Auth Documentation](https://supabase.com/docs/guides/auth)
+- [Google OAuth 2.0 Documentation](https://developers.google.com/identity/protocols/oauth2)
+- [Supabase Google Provider Setup](https://supabase.com/docs/guides/auth/social-login/auth-google)
+
+## 📞 문제 지속 시
+
+위 설정을 모두 확인한 후에도 문제가 지속되면:
+1. 브라우저 콘솔 로그
+2. Supabase Dashboard의 Authentication 로그
+3. Google Cloud Console의 OAuth 동의 화면 설정
+4. 현재 사용 중인 브라우저와 OS 정보
+
+를 포함하여 문의해주세요.

--- a/src/components/GoogleAuthDebug.tsx
+++ b/src/components/GoogleAuthDebug.tsx
@@ -19,23 +19,34 @@ export const GoogleAuthDebug: React.FC = () => {
       addDebugInfo(`Site URL: ${process.env.REACT_APP_SITE_URL || 'not set'}`);
       addDebugInfo(`Supabase URL: ${process.env.REACT_APP_SUPABASE_URL || 'not set'}`);
       addDebugInfo(`Supabase Key: ${process.env.REACT_APP_SUPABASE_ANON_KEY ? 'set' : 'not set'}`);
+      addDebugInfo(`Google Client ID: ${process.env.REACT_APP_GOOGLE_CLIENT_ID || 'not set'}`);
+      addDebugInfo(`Auth Redirect URL: ${process.env.REACT_APP_SUPABASE_AUTH_REDIRECT_URL || 'not set'}`);
       
-      // 2. Supabase 클라이언트 상태 확인
+      // 2. 현재 URL 정보
+      addDebugInfo(`Current URL: ${window.location.href}`);
+      addDebugInfo(`Current Origin: ${window.location.origin}`);
+      addDebugInfo(`Current Pathname: ${window.location.pathname}`);
+      
+      // 3. Supabase 클라이언트 상태 확인
       addDebugInfo('Checking Supabase client...');
       const session = await supabase.auth.getSession();
       addDebugInfo(`Current session: ${session.data.session ? 'exists' : 'null'}`);
       
-      // 3. OAuth URL 생성 테스트
+      // 4. OAuth URL 생성 테스트
       addDebugInfo('Testing OAuth URL generation...');
       const siteUrl = process.env.REACT_APP_SITE_URL || window.location.origin;
+      const redirectUrl = `${siteUrl}/#/auth/callback`;
+      addDebugInfo(`Using redirect URL: ${redirectUrl}`);
+      
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: `${siteUrl}/#/auth/callback`,
+          redirectTo: redirectUrl,
           queryParams: {
             access_type: 'offline',
             prompt: 'consent',
           },
+          skipBrowserRedirect: true,
         }
       });
       
@@ -46,6 +57,18 @@ export const GoogleAuthDebug: React.FC = () => {
       } else {
         addDebugInfo(`OAuth URL: ${data.url}`);
         addDebugInfo('OAuth URL generated successfully');
+        
+        // 5. URL 파라미터 분석
+        if (data.url) {
+          try {
+            const url = new URL(data.url);
+            addDebugInfo(`OAuth Provider: ${url.searchParams.get('provider')}`);
+            addDebugInfo(`OAuth Redirect To: ${url.searchParams.get('redirect_to')}`);
+            addDebugInfo(`OAuth Code Challenge Method: ${url.searchParams.get('code_challenge_method')}`);
+          } catch (e) {
+            addDebugInfo(`URL parsing error: ${e}`);
+          }
+        }
       }
       
     } catch (error: any) {

--- a/src/components/LoginScreen.tsx
+++ b/src/components/LoginScreen.tsx
@@ -61,10 +61,14 @@ export const LoginScreen: React.FC<LoginScreenProps> = ({ onLoginSuccess }) => {
       const siteUrl = process.env.REACT_APP_SITE_URL || window.location.origin;
       addDebugInfo(`Using site URL: ${siteUrl}`);
       
+      // 리다이렉트 URL 설정
+      const redirectUrl = `${siteUrl}/#/auth/callback`;
+      addDebugInfo(`Redirect URL: ${redirectUrl}`);
+      
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: `${siteUrl}/#/auth/callback`,
+          redirectTo: redirectUrl,
           queryParams: {
             access_type: 'offline',
             prompt: 'consent',

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -13,6 +13,8 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
     persistSession: true,
     detectSessionInUrl: true,
     flowType: 'pkce',
+    // OAuth 리다이렉트 URL 설정
+    redirectTo: process.env.REACT_APP_SUPABASE_AUTH_REDIRECT_URL || `${process.env.REACT_APP_SITE_URL || 'http://localhost:3000'}/#/auth/callback`,
     // 추가 설정
     debug: process.env.NODE_ENV === 'development',
   },


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Configure Supabase client with explicit OAuth redirect URL and enhance debugging for Google login issues.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The Google OAuth login was failing due to a mismatch between the expected redirect URL (`https://subscription.moonwave.kr/#/auth/callback`) and the URL being generated. This PR explicitly sets the `redirectTo` option in the Supabase client, logs the redirect URL used in the login component, and adds comprehensive debugging information to help diagnose redirect and environment variable related problems. New markdown files are also included to guide external configuration.

---

[Open in Web](https://cursor.com/agents?id=bc-7ca98e9a-4eee-4935-a213-1b1de7ba26ea) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7ca98e9a-4eee-4935-a213-1b1de7ba26ea) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)