### PR TITLE
Fix auth configuration type error

### DIFF
--- a/src/components/GoogleAuthDebug.tsx
+++ b/src/components/GoogleAuthDebug.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useSupabase } from '../contexts/SupabaseContext';
+import { getAuthRedirectUrl } from '../lib/supabase';
 
 export const GoogleAuthDebug: React.FC = () => {
   const { supabase } = useSupabase();
@@ -34,14 +35,13 @@ export const GoogleAuthDebug: React.FC = () => {
       
       // 4. OAuth URL 생성 테스트
       addDebugInfo('Testing OAuth URL generation...');
-      const siteUrl = process.env.REACT_APP_SITE_URL || window.location.origin;
-      const redirectUrl = `${siteUrl}/#/auth/callback`;
+      const redirectUrl = getAuthRedirectUrl();
       addDebugInfo(`Using redirect URL: ${redirectUrl}`);
       
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-
+          redirectTo: redirectUrl,
           queryParams: {
             access_type: 'offline',
             prompt: 'consent',

--- a/src/components/LoginScreen.tsx
+++ b/src/components/LoginScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useSupabase } from '../contexts/SupabaseContext';
 import { StepByStepSignUp } from './StepByStepSignUp';
+import { getAuthRedirectUrl } from '../lib/supabase';
 
 interface LoginScreenProps {
   onLoginSuccess: () => void;
@@ -62,13 +63,13 @@ export const LoginScreen: React.FC<LoginScreenProps> = ({ onLoginSuccess }) => {
       addDebugInfo(`Using site URL: ${siteUrl}`);
       
       // 리다이렉트 URL 설정
-      const redirectUrl = `${siteUrl}/#/auth/callback`;
+      const redirectUrl = getAuthRedirectUrl();
       addDebugInfo(`Redirect URL: ${redirectUrl}`);
       
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-
+          redirectTo: redirectUrl,
           queryParams: {
             access_type: 'offline',
             prompt: 'consent',
@@ -133,7 +134,7 @@ export const LoginScreen: React.FC<LoginScreenProps> = ({ onLoginSuccess }) => {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'kakao',
         options: {
-          redirectTo: `${window.location.origin}/`
+          redirectTo: getAuthRedirectUrl()
         }
       });
       

--- a/src/lib/authManager.ts
+++ b/src/lib/authManager.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { getAuthRedirectUrl } from './supabase';
 
 export interface UserProfile {
   id: string;
@@ -391,7 +392,7 @@ export function useAuthState(supabase: any) {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: window.location.origin,
+          redirectTo: getAuthRedirectUrl(),
           queryParams: {
             access_type: 'offline',
             prompt: 'consent',

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -13,8 +13,6 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
     persistSession: true,
     detectSessionInUrl: true,
     flowType: 'pkce',
-    // OAuth 리다이렉트 URL 설정
-    redirectTo: process.env.REACT_APP_SUPABASE_AUTH_REDIRECT_URL || `${process.env.REACT_APP_SITE_URL || 'http://localhost:3000'}/#/auth/callback`,
     // 추가 설정
     debug: process.env.NODE_ENV === 'development',
   },
@@ -25,6 +23,18 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
     },
   },
 });
+
+// OAuth 리다이렉트 URL 헬퍼 함수
+export const getAuthRedirectUrl = () => {
+  if (typeof window !== 'undefined') {
+    // 브라우저 환경에서는 현재 origin 사용
+    const siteUrl = process.env.REACT_APP_SITE_URL || window.location.origin;
+    return process.env.REACT_APP_SUPABASE_AUTH_REDIRECT_URL || `${siteUrl}/#/auth/callback`;
+  }
+  // 서버 환경에서는 환경 변수 사용
+  return process.env.REACT_APP_SUPABASE_AUTH_REDIRECT_URL || 
+         `${process.env.REACT_APP_SITE_URL || 'http://localhost:3000'}/#/auth/callback`;
+};
 
 // Supabase 클라이언트 상태 확인 함수
 export const checkSupabaseConnection = async () => {


### PR DESCRIPTION
Fixes TypeScript error by removing `redirectTo` from Supabase client config and using a helper for OAuth redirect URLs.

The `redirectTo` property was incorrectly placed in the global Supabase client configuration, leading to a `TS2322` TypeScript error. This property is intended to be passed as an option to specific authentication methods like `signInWithOAuth()`. This PR resolves the build error by removing the invalid property from the client configuration and introducing a `getAuthRedirectUrl` helper function, which is then consistently used across all OAuth sign-in implementations.

---

[Open in Web](https://cursor.com/agents?id=bc-fcee971f-0e6c-4a5c-ac04-964e1e6055bf) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-fcee971f-0e6c-4a5c-ac04-964e1e6055bf) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)